### PR TITLE
Avoid "Error: Can't set headers after they are sent."

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 exports = module.exports = function(req, res, next){
-  if(req.protocol == 'http'){
-    res.redirect('https://' + req.header('Host') + req.url)
-    next()
+  if(!req.secure){
+    res.redirect('https://' + req.header('Host') + req.url);
+  } else {
+    next();
   }
 }


### PR DESCRIPTION
Calling `next()` may cause other middleware to attempt to send headers after they've already been sent, and at this point we've already made a decision on where to send the user.

The change to use `req.secure` is purely semantics; it's equivalent to the previous `req.protocol` check because Express rolls in the value of `X-Forward-Proto` according to the `trust proxy` setting.
