### PR TITLE
Use HTTP code 301

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ exports = module.exports = function(req, res, next){
   if(!req.secure){
     var httpsPort = req.app.get('httpsPort') || 443;
     var fullUrl = parseUrl('http://' + req.header('Host') + req.url);
-    res.redirect('https://' + fullUrl.hostname + ':' + httpsPort + req.url);
+    res.redirect(301, 'https://' + fullUrl.hostname + ':' + httpsPort + req.url);
   } else {
     next();
   }


### PR DESCRIPTION
This works well with express 4.x, however I'd recommend using HTTP code 301 "Moved Permanently"
