### PR TITLE
check 'x-forwarded-proto' for 'https' as well

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var parseUrl = require('url').parse;
 var isSecure = function(req) {
   if (req.secure) {
     return true;
-  } else if (req.get('X-Forwarded-Proto') === 'https') {
+  } else if (req.get('X-Forwarded-Proto').toLowerCase() === 'https') {
     return true;
   }
   return false;


### PR DESCRIPTION
This PR will add support for recognizing the originating protocol when express is running behind a reverse proxy/load balancer.  It checks the 'x-forwarded-proto' header in addition to checking if `req.secure` is true.
