### PR TITLE
Protect against undefined error on header not set

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,11 @@ var parseUrl = require('url').parse;
 var isSecure = function(req) {
   if (req.secure) {
     return true;
-  } else if (req.get('X-Forwarded-Proto').toLowerCase() === 'https') {
+  } else if (
+    typeof req.get('X-Forwarded-Proto') !== 'undefined' &&
+    typeof req.get('X-Forwarded-Proto').toLowerCase !== 'undefined' &&
+    req.get('X-Forwarded-Proto').toLowerCase() === 'https'
+    ) {
     return true;
   }
   return false;


### PR DESCRIPTION
This should fix issue #8 created in with my previous PR #7.

I've tested it locally with no proxy and the error is resolved.  I'm currently deploying to a load-balanced environment to confirm that behavior still works, but I think this is good to go.

Let me know if you'd like me to bring in a test framework and write some unit tests on this.

-Ron
