### PR TITLE
Add option to prevent redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ var server = http.createServer(app);
 var secureServer = https.createServer(ssl_options, app);
 
 app.use(express.bodyParser());
-app.use(forceSSL);
+app.use(forceSSL());
 app.use(app.router);
 
 secureServer.listen(443)
@@ -66,8 +66,8 @@ app.use(app.router);
 
 app.get('/', somePublicFunction);
 app.get('/user/:name', somePublicFunction);
-app.get('/login', forceSSL, someSecureFunction);
-app.get('/logout', forceSSL, someSecureFunction);
+app.get('/login', forceSSL(), someSecureFunction);
+app.get('/logout', forceSSL(), someSecureFunction);
 
 secureServer.listen(443)
 server.listen(80)
@@ -75,7 +75,7 @@ server.listen(80)
 
 Custom Server Port Support
 --------------------------
-If your server isn't listening on 80/443 respectively, you can change this pretty simply. 
+If your server isn't listening on 80/443 respectively, you can change this pretty simply.
 
 ```javascript
 

--- a/examples/example.js
+++ b/examples/example.js
@@ -18,11 +18,11 @@ var secureServer = https.createServer(ssl_options, app);
 app.get('/', function(req, res){
   res.json({msg: 'accessible by http'});
 });
-app.get('/ssl', forceSSL, function(req, res){
+app.get('/ssl', forceSSL(), function(req, res){
   res.json({msg: 'only https'});
 });
 
-app.get('/ssl/deep/route/:id', forceSSL, function(req, res){
+app.get('/ssl/deep/route/:id', forceSSL(), function(req, res){
   var host = req.headers.host.split(':');
   var port = host.length > 1 ? host[1] : 'default port';
   res.json({msg: 'only https, port: ' + port, id: req.param('id')});

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "https",
     "express"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "underscore": "~1.8.2"
+  },
   "main": "index",
   "bugs": {
     "url": "http://github.com/battlejj/express-force-ssl/issues"

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -29,11 +29,11 @@ module.exports = (function() {
     res.send('HTTP and HTTPS.');
   });
 
-  app.get('/ssl', forceSSL, function (req, res) {
+  app.get('/ssl', forceSSL(), function (req, res) {
     res.send('HTTPS only.');
   });
 
-  app.get('/ssl/nested/route/:id', forceSSL, function (req, res) {
+  app.get('/ssl/nested/route/:id', forceSSL(), function (req, res) {
     var host = req.headers.host.split(':');
     var port = host.length > 1 ? host[1] : 'default port';
     res.send('HTTPS Only. Port: ' + port + '. Got param of ' + req.param('id') + '.');
@@ -43,7 +43,7 @@ module.exports = (function() {
     res.json(req.body);
   });
 
-  app.post('/sslEcho', forceSSL, function (req, res) {
+  app.post('/sslEcho', forceSSL(), function (req, res) {
     res.json(req.body);
   });
 
@@ -58,4 +58,3 @@ module.exports = (function() {
     app: app
   };
 })();
-


### PR DESCRIPTION
I needed to prevent redirects from HTTP to HTTPS for GET requests, this introduces an `options` arg and an `allowRedirects` option (default `true`, previous behavior). Updates usage in README, tests, examples