### PR TITLE
Export factory instead of a middleware function and other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Force SSL on all pages
 ----------------------
 ```javascript
 var express = require('express');
-var forceSSL = require('express-force-ssl');
+var forceSSL = require('express-force-ssl')();
 var fs = require('fs');
 var http = require('http');
 var https = require('https');
@@ -38,14 +38,13 @@ app.use(app.router);
 
 secureServer.listen(443)
 server.listen(80)
-
 ```
 
 Only certain pages SSL
 ----------------------
 ```javascript
 var express = require('express');
-var forceSSL = require('express-force-ssl');
+var forceSSL = require('express-force-ssl')();
 var fs = require('fs');
 var http = require('http');
 var https = require('https');
@@ -75,21 +74,28 @@ server.listen(80)
 
 Custom Server Port Support
 --------------------------
-If your server isn't listening on 80/443 respectively, you can change this pretty simply. 
+If your server isn't listening on 80/443 respectively, you can change this pretty simply.
 
 ```javascript
+var forceSSL = require('express-force-ssl')({ port: 8443 });
 
 var app = express();
-app.set('httpsPort', 8443);
 
 var server = http.createServer(app);
 var secureServer = https.createServer(ssl_options, app);
 
 ...
 
-secureServer.listen(443)
+secureServer.listen(8443)
 server.listen(80)
+```
 
+Custom Error Response
+--------------------------
+You can change the default 403 response message by setting the `errorResponse` option like so:
+
+```javascript
+var forceSSL = require('express-force-ssl')({ errorResponse: 'SSL really required.' });
 ```
 
 Test

--- a/index.js
+++ b/index.js
@@ -1,26 +1,46 @@
-var parseUrl = require('url').parse;
-var isSecure = function(req) {
+'use strict';
+
+var defaultSSLPort = 443;
+var defaultErrorResponse = 'SSL Required.';
+
+
+function isSecure(req) {
   if (req.secure) {
     return true;
-  } else if (
-    req.get('X-Forwarded-Proto') &&
-    req.get('X-Forwarded-Proto').toLowerCase &&
-    req.get('X-Forwarded-Proto').toLowerCase() === 'https'
-    ) {
+  }
+
+  var forwardedProto = req.get('X-Forwarded-Proto');
+
+  if (forwardedProto &&
+      forwardedProto.toLowerCase &&
+      forwardedProto.toLowerCase() === 'https') {
     return true;
   }
+
   return false;
-};
-exports = module.exports = function(req, res, next){
-  if(!isSecure(req)){
-    if(req.method === "GET"){
-      var httpsPort = req.app.get('httpsPort') || 443;
-      var fullUrl = parseUrl(req.protocol + '://' + req.header('Host') + req.originalUrl);
-      res.redirect(301, 'https://' + fullUrl.hostname + ':' + httpsPort + req.originalUrl);
-    } else {
-      res.status(403).send('SSL Required.');
-    }
-  } else {
-    next();
+}
+
+
+module.exports = function getForceSSL(options) {
+  var portPart = '';
+
+  if (options.port &&
+      options.port !== defaultSSLPort) {
+    portPart = ':' + options.port;
   }
+
+  var errorResponse = options.errorResponse || defaultErrorResponse;
+
+  return function forceSSL(req, res, next) {
+    if (isSecure(req)) {
+      return next();
+    }
+
+    if (req.method !== 'GET') {
+      res.status(403).send(errorResponse);
+      return;
+    }
+
+    res.redirect(301, 'https://' + req.hostname + portPart + req.originalUrl);
+  };
 };

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ function isSecure(req) {
 
 
 module.exports = function getForceSSL(options) {
+  options = options || {};
+
   var portPart = '';
 
   if (options.port &&

--- a/test/http.js
+++ b/test/http.js
@@ -8,6 +8,7 @@ var baseurl = 'http://localhost:8080';
 var secureBaseurl = 'https://localhost:8443';
 var secureBaseurlDefaultPort = 'https://localhost';
 var SSLRequiredErrorText = 'SSL Required.';
+var SSLRequiredCustomErrorText = 'Oh noes, y u got no SSL?';
 
 describe('Test standard HTTP behavior.', function(){
 
@@ -160,6 +161,24 @@ describe('Test standard HTTP behavior.', function(){
       expect(response.statusCode).to.equal(403);
       expect(response.request.uri.href).to.equal(destination);
       expect(body).to.equal(SSLRequiredErrorText);
+      done();
+    });
+  });
+
+  it('Should receive 403 error with a custom error message when POSTing data to "SSL Only" endpoint.', function(done){
+    var destination = baseurl + '/customReponse';
+    var postData = { key1: 'Keyboard.', key2: 'Cat.'};
+    request.post({
+      url: destination,
+      followRedirect: true,
+      strictSSL: false,
+      form: postData
+    }, function(error, response, body){
+      //noinspection BadExpressionStatementJS
+      expect(error).to.not.exist;
+      expect(response.statusCode).to.equal(403);
+      expect(response.request.uri.href).to.equal(destination);
+      expect(body).to.equal(SSLRequiredCustomErrorText);
       done();
     });
   });

--- a/test/http.js
+++ b/test/http.js
@@ -6,6 +6,7 @@ var chai = require('chai')
 
 var baseurl = 'http://localhost:8080';
 var secureBaseurl = 'https://localhost:8443';
+var secureBaseurlDefaultPort = 'https://localhost';
 var SSLRequiredErrorText = 'SSL Required.';
 
 describe('Test standard HTTP behavior.', function(){
@@ -42,6 +43,38 @@ describe('Test standard HTTP behavior.', function(){
   it('Should end up at secure endpoint on "SSL Only" endpoint.', function(done){
     var originalDestination = baseurl + '/ssl';
     var expectedDestination = secureBaseurl + '/ssl';
+    request.get({
+      url: originalDestination,
+      followRedirect: true,
+      strictSSL: false
+    }, function (error, response, body){
+      //noinspection BadExpressionStatementJS
+      expect(error).to.not.exist;
+      expect(response.statusCode).to.equal(200);
+      expect(response.request.uri.href).to.equal(expectedDestination);
+      done();
+    });
+  });
+
+  it('Should receive a 301 redirect on "SSL Only" endpoint (default SSL port).', function(done){
+    var originalDestination = baseurl + '/sslDefaultPort';
+    var expectedDestination = secureBaseurlDefaultPort + '/sslDefaultPort';
+    request.get({
+      url: originalDestination,
+      followRedirect: false,
+      strictSSL: false
+    }, function (error, response, body){
+      //noinspection BadExpressionStatementJS
+      expect(error).to.not.exist;
+      expect(response.statusCode).to.equal(301);
+      expect(response.headers.location).to.equal(expectedDestination);
+      done();
+    });
+  });
+
+  it('Should end up at secure endpoint on "SSL Only" endpoint (default SSL port).', function(done){
+    var originalDestination = baseurl + '/sslDefaultPort';
+    var expectedDestination = secureBaseurlDefaultPort + '/sslDefaultPort';
     request.get({
       url: originalDestination,
       followRedirect: true,

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -1,6 +1,10 @@
+var httpsPort = 8443;
+var defaultSSLPort =  443;
 var bodyParser = require('body-parser')
   , express = require('express')
-  , forceSSL = require('../../index')
+  , getForceSSL = require('../../index')
+  , forceSSL = getForceSSL({ port: httpsPort })
+  , forceSSLDefaultPort = getForceSSL({ port: defaultSSLPort })
   , fs = require('fs')
   , http = require('http')
   , https = require('https')
@@ -21,6 +25,7 @@ module.exports = (function() {
 
   var server = http.createServer(app);
   var secureServer = https.createServer(ssl_options, app);
+  var secureServerWithDefaultPort = https.createServer(ssl_options, app);
 
   /*
    Routes
@@ -33,10 +38,14 @@ module.exports = (function() {
     res.send('HTTPS only.');
   });
 
+  app.get('/sslDefaultPort', forceSSLDefaultPort, function (req, res) {
+    res.send('HTTPS only.');
+  });
+
   app.get('/ssl/nested/route/:id', forceSSL, function (req, res) {
     var host = req.headers.host.split(':');
     var port = host.length > 1 ? host[1] : 'default port';
-    res.send('HTTPS Only. Port: ' + port + '. Got param of ' + req.param('id') + '.');
+    res.send('HTTPS Only. Port: ' + port + '. Got param of ' + req.params.id + '.');
   });
 
   app.post('/echo', function (req, res) {
@@ -47,15 +56,15 @@ module.exports = (function() {
     res.json(req.body);
   });
 
-  app.set('httpsPort', 8443);
-
-  secureServer.listen(8443);
   server.listen(8080);
+  secureServer.listen(httpsPort);
+  secureServerWithDefaultPort.listen(defaultSSLPort);
 
   return {
-    secureServer: secureServer,
+    app: app,
     server: server,
-    app: app
+    secureServer: secureServer,
+    secureServerWithDefaultPort: secureServerWithDefaultPort,
   };
 })();
 

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -1,10 +1,13 @@
 var httpsPort = 8443;
 var defaultSSLPort =  443;
+var customReponse = 'Oh noes, y u got no SSL?';
+
 var bodyParser = require('body-parser')
   , express = require('express')
   , getForceSSL = require('../../index')
   , forceSSL = getForceSSL({ port: httpsPort })
   , forceSSLDefaultPort = getForceSSL({ port: defaultSSLPort })
+  , forceSSLCustomResponse = getForceSSL({ errorResponse: customReponse })
   , fs = require('fs')
   , http = require('http')
   , https = require('https')
@@ -54,6 +57,10 @@ module.exports = (function() {
 
   app.post('/sslEcho', forceSSL, function (req, res) {
     res.json(req.body);
+  });
+
+  app.post('/customReponse', forceSSLCustomResponse, function (req, res) {
+    res.send('HTTPS only.');
   });
 
   server.listen(8080);


### PR DESCRIPTION
I know this is a breaking change, but it could prove useful.

## Changes

#### Exporting factory instead of a middleware function

This lets us pass the options to the factory instead of cluttering Express settings. As a result, the options are not global, so using multiple differently configured middleware functions is possible. This should also solve #18.

#### Hiding the port part of the URL

When the port option is empty or equal to the default SSL port - 443, then the port part of the URL is omitted. I didn't see any point in attaching the port number when it is already guessed by the browser. As an afterthought, the port could still be added if the user specified it explicitly.

#### Custom error message

By setting the `errorResponse` option it is possible to change the default error message. This could be used for localization.

-

I've provided tests for all of the above and also updated the README.