### PR TITLE
feat: upgrades node requirement to use builtin Object.assign method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var parseUrl = require('url').parse;
-var assign = require('lodash.assign');
 
 function isSecure (secure, xfpHeader, trustXFPHeader) {
   xfpHeader = xfpHeader ? xfpHeader.toString().toLowerCase() : '';
@@ -54,7 +53,7 @@ module.exports = function(req, res, next){
   var expressOptions = req.app.get('forceSSLOptions') || {};
   var localOptions = res.locals.forceSSLOptions || {};
   localHttpsPort = localOptions.httpsPort;
-  assign(options, expressOptions, localOptions);
+  Object.assign(options, expressOptions, localOptions);
 
   secure = isSecure(req.secure, xfpHeader, options.trustXFPHeader);
   redirect = shouldRedirect(options.enable301Redirects, req.method);

--- a/package.json
+++ b/package.json
@@ -23,15 +23,12 @@
     "https",
     "express"
   ],
-  "dependencies": {
-    "lodash.assign": "^3.2.0"
-  },
   "main": "index",
   "bugs": {
     "url": "http://github.com/battlejj/express-force-ssl/issues"
   },
   "engines": {
-    "node": ">=0.2.2"
+    "node": ">=6.11"
   },
   "licenses": [
     {


### PR DESCRIPTION
Hi! Thank you for this repo, it has proven to stand the test of time, especially in npm land

I was going to go through and give it the full TLC treatment to "modernize" it, but I decided to go with the minimum to improve the library by replacing `lodash.assign@3.2.0` with the native Object.assign and requiring the latest node LTS [at time of writing] :)

I think this would warrant a v1.0 release, which I would be happy to do if you don't have time @battlejj. Thanks again!